### PR TITLE
MIST-286 Fix || to && for conditional candidate resource filtering

### DIFF
--- a/guest.go
+++ b/guest.go
@@ -241,7 +241,7 @@ func CandidateHasResources(g *Guest, hs Hypervisors) (Hypervisors, error) {
 	var hypervisors Hypervisors
 	for _, h := range hs {
 		avail := h.AvailableResources
-		if avail.Disk >= f.Disk || avail.Memory >= f.Memory || avail.CPU >= f.CPU {
+		if avail.Disk >= f.Disk && avail.Memory >= f.Memory && avail.CPU >= f.CPU {
 			hypervisors = append(hypervisors, h)
 		}
 	}


### PR DESCRIPTION
We want the candidate to have sufficient available disk, memory, AND CPU
rather than just at least one.
