### PR TITLE
MIST-286 Make default ttl be 2*interval at runtime

### DIFF
--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -12,10 +12,14 @@ import (
 
 func main() {
 	interval := flag.Int("interval", 60, "update interval in seconds")
-	ttl := flag.Int("ttl", 2*(*interval), "heartbeat ttl in seconds")
+	ttl := flag.Int("ttl", 0, "heartbeat ttl in seconds. leave 0 for (2 * interval)")
 	eaddr := flag.String("etcd", "http://localhost:4001", "address of etcd machine")
 	id := flag.String("id", "", "hypervisor id")
 	flag.Parse()
+
+	if *ttl == 0 {
+		*ttl = 2 * (*interval)
+	}
 
 	e := etcd.NewClient([]string{*eaddr})
 	c := lochness.NewContext(e)


### PR DESCRIPTION
Using `2*(*interval)` in the flag default for ttl gets evaluated with the interval default, and thus ttl was always 120 if omitted regardless of what interval was specified. Update to work like `cmd/lock` does, where it calculates the the default ttl once interval is known at runtime.
