### PR TITLE
MIST-376 Add an Image field to Flavor and client.Guest for use with containers

### DIFF
--- a/flavor.go
+++ b/flavor.go
@@ -19,6 +19,7 @@ type (
 		context       *Context
 		modifiedIndex uint64
 		ID            string            `json:"id"`
+		Image         string            `json:"image"`
 		Metadata      map[string]string `json:"metadata"`
 		Resources
 	}

--- a/mistifyagent.go
+++ b/mistifyagent.go
@@ -73,6 +73,7 @@ func (agent *MistifyAgent) generateClientGuest(g *Guest) (*client.Guest, error) 
 	return &client.Guest{
 		Id:       g.ID,
 		Type:     g.Type,
+		Image:    flavor.Image,
 		Nics:     []client.Nic{nic},
 		Disks:    []client.Disk{disk},
 		Memory:   uint(flavor.Memory),


### PR DESCRIPTION
We're treating containers like guests, but they need a docker image to pull
Related:
https://github.com/mistifyio/mistify-agent/pull/37
https://github.com/mistifyio/mistify-agent-docker/pull/1

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/lochness/85)

<!-- Reviewable:end -->
