### PR TITLE
MIST-286 heartbeat logging

### DIFF
--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -65,7 +65,6 @@ func main() {
 				"ttl":   *ttl,
 			}).Error("failed to beat heart")
 		}
-		log.Info("♥")
 		time.Sleep(time.Duration(*interval) * time.Second)
 	}
 }


### PR DESCRIPTION
Replace the `os.Stdout` calls with logrus log calls. Additionally, use our mistify-logrus-ext for formatting/setup and add a log level flag.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/lochness/87)

<!-- Reviewable:end -->
