### PR TITLE
MIST-410 heartbeat: exit if an error was hit

### DIFF
--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -56,14 +56,14 @@ func main() {
 			log.WithFields(log.Fields{
 				"error": err,
 				"func":  "hv.UpdateResources",
-			}).Error("failed to update hypervisor resources")
+			}).Fatal("failed to update hypervisor resources")
 		}
 		if err = hv.Heartbeat(time.Duration(*ttl)); err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
 				"func":  "hv.Heartbeat",
 				"ttl":   *ttl,
-			}).Error("failed to beat heart")
+			}).Fatal("failed to beat heart")
 		}
 		time.Sleep(time.Duration(*interval) * time.Second)
 	}


### PR DESCRIPTION
heartbeat did not exit but it also did nothing to try to recover from the error,
which meant an infinite loop of error messages :(. heartbeat now exits, this
will effectively recover from all currently known errors.

MIST-410

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/lochness/98)

<!-- Reviewable:end -->
