### PR TITLE
MIST-446 Use image id and type instead of source when making a fetch request

### DIFF
--- a/mistifyagent.go
+++ b/mistifyagent.go
@@ -274,9 +274,8 @@ func (agent *MistifyAgent) FetchImage(guestID string) (string, error) {
 
 	host := hypervisor.IP.String()
 	req := &rpc.ImageRequest{
-		// TODO: Revisit this so sources can be custom and still work with
-		// image fetching and libvirt
-		Source: fmt.Sprintf("http://builds.mistify.io/guest-images/%s.gz", flavor.Image),
+		Id:   flavor.Image,
+		Type: guest.Type,
 	}
 	url := fmt.Sprintf("http://%s:8080/images", host) // TODO: Get port from somewhere. Config?
 	_, jobID, err := agent.request(url, "POST", http.StatusAccepted, req)


### PR DESCRIPTION
The subagents will fetch from the image service and just need the image id, while the type is used to route the request to the appropriate subagent. Requires https://github.com/mistifyio/mistify-agent-docker/pull/7 and https://github.com/mistifyio/mistify-agent/pull/45 for container images.

NOTE: This should not be merged until MIST-445 is completed, updating the image subagent to pull from the image service.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/lochness/103)

<!-- Reviewable:end -->
