### PR TITLE
MIST-552 cnetworkd and VLAN tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,17 @@ cmd/cguestd/cguestd: cmd/cguestd/main.go \
 $(SBIN_DIR)/cguestd: cmd/cguestd/cguestd
 	install -D $< $(DESTDIR)$@
 
+cmd/cnetworkd/cnetworkd: cmd/cnetworkd/main.go \
+		cmd/cnetworkd/vlan.go \
+		cmd/cnetworkd/vlangroup.go \
+		cmd/cnetworkd/helpers.go \
+		cmd/cnetworkd/http.go
+	cd $(dir $<) && \
+	go get && \
+	go build -v
+
+$(SBIN_DIR)/cnetworkd: cmd/cnetworkd/cnetworkd
+	install -D $< $(DESTDIR)$@
 
 clean:
 	cd cmd/nfirewalld && \
@@ -127,6 +138,9 @@ clean:
 	cd cmd/cguestd && \
 	go clean -x
 
+	cd cmd/cnetworkd && \
+	go clean -x
+
 
 install: \
   $(SBIN_DIR)/nfirewalld \
@@ -138,4 +152,5 @@ install: \
   $(SBIN_DIR)/nconfigd \
   $(SBIN_DIR)/cplacerd \
   $(SBIN_DIR)/cguestd \
+  $(SBIN_DIR)/cnetworkd \
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ var (
 )
 ```
 
+```go
+var (
+	// VLANGroupPath is the path in the config store for VLAN groups
+	VLANGroupPath = "/lochness/vlangroups/"
+)
+```
+
+```go
+var (
+	// VLANPath is the path in the config store for VLANs
+	VLANPath = "/lochness/vlans/"
+)
+```
+
 #### func  GetHypervisorID
 
 ```go
@@ -310,6 +324,20 @@ func (c *Context) NewSubnet() *Subnet
 NewSubnet creates a new "blank" subnet. Fill in the needed values and then call
 Save
 
+#### func (*Context) NewVLAN
+
+```go
+func (c *Context) NewVLAN() *VLAN
+```
+NewVLAN creates a new blank VLAN.
+
+#### func (*Context) NewVLANGroup
+
+```go
+func (c *Context) NewVLANGroup() *VLANGroup
+```
+NewVLANGroup creates a new blank VLANGroup.
+
 #### func (*Context) SetConfig
 
 ```go
@@ -324,6 +352,20 @@ SetConfig sets a single value from the config store. The key can contain slashes
 func (c *Context) Subnet(id string) (*Subnet, error)
 ```
 Subnet fetches a single subnet by ID
+
+#### func (*Context) VLAN
+
+```go
+func (c *Context) VLAN(tag int) (*VLAN, error)
+```
+VLAN fetches a VLAN from the data store.
+
+#### func (*Context) VLANGroup
+
+```go
+func (c *Context) VLANGroup(id string) (*VLANGroup, error)
+```
+VLANGroup fetches a VLAN from the data store.
 
 #### type ErrorHTTPCode
 
@@ -993,6 +1035,129 @@ type Subnets []*Subnet
 ```
 
 Subnets is an alias to a slice of *Subnet
+
+#### type VLAN
+
+```go
+type VLAN struct {
+	Tag         int    `json:"tag"`
+	Description string `json:"description"`
+}
+```
+
+VLAN devines the virtual lan for a guest interface
+
+#### func (*VLAN) Destroy
+
+```go
+func (v *VLAN) Destroy() error
+```
+Destroy removes the VLAN
+
+#### func (*VLAN) Refresh
+
+```go
+func (v *VLAN) Refresh() error
+```
+Refresh reloads the VLAN from the data store.
+
+#### func (*VLAN) Save
+
+```go
+func (v *VLAN) Save() error
+```
+Save persists a VLAN. It will call Validate.
+
+#### func (*VLAN) VLANGroups
+
+```go
+func (v *VLAN) VLANGroups() []string
+```
+VLANGroups returns the IDs of the VLANGroups associated with the VLAN
+
+#### func (*VLAN) Validate
+
+```go
+func (v *VLAN) Validate() error
+```
+Validate ensures a VLAN has resonable data.
+
+#### type VLANGroup
+
+```go
+type VLANGroup struct {
+	ID          string            `json:"id"`
+	Description string            `json:"description"`
+	Metadata    map[string]string `json:"metadata"`
+}
+```
+
+VLANGroup defines a set of VLANs for a guest interface
+
+#### func (*VLANGroup) AddVLAN
+
+```go
+func (vg *VLANGroup) AddVLAN(vlan *VLAN) error
+```
+AddVLAN adds a VLAN to the VLANGroup
+
+#### func (*VLANGroup) Destroy
+
+```go
+func (vg *VLANGroup) Destroy() error
+```
+Destroy removes a VLANGroup
+
+#### func (*VLANGroup) Refresh
+
+```go
+func (vg *VLANGroup) Refresh() error
+```
+Refresh reloads the VLAN from the data store.
+
+#### func (*VLANGroup) RemoveVLAN
+
+```go
+func (vg *VLANGroup) RemoveVLAN(vlan *VLAN) error
+```
+RemoveVLAN removes a VLAN from the VLANGroup
+
+#### func (*VLANGroup) Save
+
+```go
+func (vg *VLANGroup) Save() error
+```
+Save persists a VLANgroup. It will call Validate.
+
+#### func (*VLANGroup) VLANs
+
+```go
+func (vg *VLANGroup) VLANs() []int
+```
+VLANs returns the Tags of the VLANs associated with the VLANGroup
+
+#### func (*VLANGroup) Validate
+
+```go
+func (vg *VLANGroup) Validate() error
+```
+Validate ensures a VLANGroup has resonable data.
+
+#### type VLANGroups
+
+```go
+type VLANGroups []*VLANGroup
+```
+
+VLANGroups is an alias to a slice of *VLANGroup
+
+#### type VLANs
+
+```go
+type VLANs []*VLAN
+```
+
+VLANs is an alias to a slice of *VLAN
 
 --
 *Generated with [godocdown](https://github.com/robertkrimen/godocdown)*

--- a/cmd/cnetworkd/.gitignore
+++ b/cmd/cnetworkd/.gitignore
@@ -1,0 +1,1 @@
+cnetworkd

--- a/cmd/cnetworkd/README.md
+++ b/cmd/cnetworkd/README.md
@@ -1,0 +1,140 @@
+# cnetworkd
+
+[![cnetworkd](https://godoc.org/github.com/mistifyio/lochness/cmd/cnetworkd?status.png)](https://godoc.org/github.com/mistifyio/lochness/cmd/cnetworkd)
+
+cnetworkd is the network configuration management service. It exposes
+functionality over an HTTP API with JSON formatting.
+
+
+### Usage
+
+The following arguments are understood:
+
+    ./cnetworkd -h
+    Usage of ./cnetworkd:
+    -e, --etcd="http://localhost:4001": address of etcd machine
+    -l, --log-level="warn": log level
+    -p, --port=19000: listen port
+
+HTTP API endpoints
+
+    /vlans/tags
+    	* GET - Retrieve a list of VLAN tags
+    	* POST - Add a new VLAN tag
+
+    /vlans/tags/{vlanTag}
+    	* GET - Retrieve information about a VLAN tag
+    	* PATCH - Update a VLAN tag's information
+    	* DELETE - Remove a VLAN tag
+
+    /vlans/tags/{vlanTag}/groups
+    	* GET - Retrieve a list of VLAN groups the VLAN tag belongs to
+    	* POST - Set the list of VLAN groups the VLAN tag belongs to
+
+    /vlans/groups
+    	* GET - Retrieve a list of VLAN groups
+    	* POST - Add a new VLAN tag
+
+    /vlans/groups/{vlanGroupID}
+    	* GET - Retrieve information about a VLAN group
+    	* PATCH - Update a VLAN group's information
+    	* DELETE - Remove a VLAN group
+
+    /vlans/tags/{vlanGroupID}/tags
+    	* GET - Retrieve a list of VLAN tags the VLAN group contains
+    	* POST - Set the list of VLAN tags the VLAN group contains
+
+
+### Example Structs
+
+VLAN tag - lochness.VLAN
+
+    {
+    	"tag": 219,
+    	"description": "foobar"
+    }
+
+VLAN Group - lochness.VLANGroup
+
+    {
+    	"id": "122be0b1-d621-4bf5-8b6b-6d0ce41d7c11",
+    	"description": "foobar",
+    	"metadata": {}
+    }
+
+
+### Example Requests
+
+GET /vlans/tags
+
+    $ curl http://localhost:19000/vlans/tags
+    [{"tag":219,"description":"baz"}]
+
+POST /vlans/tags
+
+    $ curl -X POST http://localhost:19000/vlans/tags --data-binary '{"tag":123,"description":"another tag"}'
+    {"tag":123,"description":"another tag"}
+
+GET /vlans/tags/{vlanTag}
+
+    $ curl http://localhost:19000/vlans/tags/219
+    {"tag":219,"description":"baz"}
+
+PATCH /vlans/tags/{vlanTag}
+
+    $ curl -X PATCH http://localhost:19000/vlans/tags/123 --data-binary '{"description":"updated description"}'
+    {"tag":123,"description":"updated description"}
+
+DELETE /vlans/tags/{vlanTag}
+
+    $ curl -X DELETE http://localhost:19000/vlans/tags/123
+    {"tag":123,"description":"updated description"}
+
+GET /vlans/tags/{vlanTag}/groups
+
+    $ curl -X GET http://localhost:19000/vlans/tags/219/groups
+    ["122be0b1-d621-4bf5-8b6b-6d0ce41d7c11"]
+
+POST /vlans/tags/{vlanTag}/groups
+
+    $ curl -X POST http://localhost:19000/vlans/tags/219/groups --data-binary '["122be0b1-d621-4bf5-8b6b-6d0ce41d7c11"]'
+    ["122be0b1-d621-4bf5-8b6b-6d0ce41d7c11"]
+
+GET /vlans/groups
+
+    $ curl http://localhost:19000/vlans/groups
+    [{"id":"122be0b1-d621-4bf5-8b6b-6d0ce41d7c11","description":"a group!","metadata":{}}]
+
+POST /vlans/groups
+
+    $ curl -X POST http://localhost:19000/vlans/groups --data-binary '{"description":"another group"}'
+    {"id":"89be5c67-3ddc-4ca3-acbb-f78d96181aa9","description":"another group","metadata":{}}
+
+GET /vlans/groups/{vlanGroupID}
+
+    $ curl http://localhost:19000/vlans/groups/122be0b1-d621-4bf5-8b6b-6d0ce41d7c11
+    {"id":"122be0b1-d621-4bf5-8b6b-6d0ce41d7c11","description":"a group!","metadata":{}}
+
+PATCH /vlans/groups/{vlanGroupID}
+
+    $ curl -X PATCH http://localhost:19000/vlans/groups/89be5c67-3ddc-4ca3-acbb-f78d96181aa9 --data-binary '{"description":"updated description"}'
+    {"id":"89be5c67-3ddc-4ca3-acbb-f78d96181aa9","description":"updated description","metadata":{}}
+
+DELETE /vlans/groups/{vlanGroupID}
+
+    $ curl -X DELETE http://localhost:19000/vlans/groups/89be5c67-3ddc-4ca3-acbb-f78d96181aa9
+    {"id":"89be5c67-3ddc-4ca3-acbb-f78d96181aa9","description":"updated description","metadata":{}}
+
+GET /vlans/tags/{vlanGroupID}/tags
+
+    $ curl -X GET http://localhost:19000/vlans/groups/122be0b1-d621-4bf5-8b6b-6d0ce41d7c11/tags
+    [219]
+
+POST /vlans/tags/{vlanGroupID}/tags
+
+    $ curl -X POST http://localhost:19000/vlans/groups/122be0b1-d621-4bf5-8b6b-6d0ce41d7c11/tags --data-binary '[219]'
+    [219]
+
+
+--
+*Generated with [godocdown](https://github.com/robertkrimen/godocdown)*

--- a/cmd/cnetworkd/doc.go
+++ b/cmd/cnetworkd/doc.go
@@ -1,0 +1,131 @@
+/*
+cnetworkd is the network configuration management service. It exposes functionality over an HTTP API with JSON formatting.
+
+Usage
+
+The following arguments are understood:
+
+	./cnetworkd -h
+	Usage of ./cnetworkd:
+	-e, --etcd="http://localhost:4001": address of etcd machine
+	-l, --log-level="warn": log level
+	-p, --port=19000: listen port
+
+HTTP API endpoints
+
+	/vlans/tags
+		* GET - Retrieve a list of VLAN tags
+		* POST - Add a new VLAN tag
+
+	/vlans/tags/{vlanTag}
+		* GET - Retrieve information about a VLAN tag
+		* PATCH - Update a VLAN tag's information
+		* DELETE - Remove a VLAN tag
+
+	/vlans/tags/{vlanTag}/groups
+		* GET - Retrieve a list of VLAN groups the VLAN tag belongs to
+		* POST - Set the list of VLAN groups the VLAN tag belongs to
+
+	/vlans/groups
+		* GET - Retrieve a list of VLAN groups
+		* POST - Add a new VLAN tag
+
+	/vlans/groups/{vlanGroupID}
+		* GET - Retrieve information about a VLAN group
+		* PATCH - Update a VLAN group's information
+		* DELETE - Remove a VLAN group
+
+	/vlans/tags/{vlanGroupID}/tags
+		* GET - Retrieve a list of VLAN tags the VLAN group contains
+		* POST - Set the list of VLAN tags the VLAN group contains
+
+Example Structs
+
+VLAN tag - lochness.VLAN
+
+	{
+		"tag": 219,
+		"description": "foobar"
+	}
+
+VLAN Group - lochness.VLANGroup
+
+	{
+		"id": "122be0b1-d621-4bf5-8b6b-6d0ce41d7c11",
+		"description": "foobar",
+		"metadata": {}
+	}
+
+Example Requests
+
+GET /vlans/tags
+
+	$ curl http://localhost:19000/vlans/tags
+	[{"tag":219,"description":"baz"}]
+
+POST /vlans/tags
+
+	$ curl -X POST http://localhost:19000/vlans/tags --data-binary '{"tag":123,"description":"another tag"}'
+	{"tag":123,"description":"another tag"}
+
+GET /vlans/tags/{vlanTag}
+
+	$ curl http://localhost:19000/vlans/tags/219
+	{"tag":219,"description":"baz"}
+
+PATCH /vlans/tags/{vlanTag}
+
+	$ curl -X PATCH http://localhost:19000/vlans/tags/123 --data-binary '{"description":"updated description"}'
+	{"tag":123,"description":"updated description"}
+
+DELETE /vlans/tags/{vlanTag}
+
+	$ curl -X DELETE http://localhost:19000/vlans/tags/123
+	{"tag":123,"description":"updated description"}
+
+GET /vlans/tags/{vlanTag}/groups
+
+	$ curl -X GET http://localhost:19000/vlans/tags/219/groups
+	["122be0b1-d621-4bf5-8b6b-6d0ce41d7c11"]
+
+POST /vlans/tags/{vlanTag}/groups
+
+	$ curl -X POST http://localhost:19000/vlans/tags/219/groups --data-binary '["122be0b1-d621-4bf5-8b6b-6d0ce41d7c11"]'
+	["122be0b1-d621-4bf5-8b6b-6d0ce41d7c11"]
+
+GET /vlans/groups
+
+	$ curl http://localhost:19000/vlans/groups
+	[{"id":"122be0b1-d621-4bf5-8b6b-6d0ce41d7c11","description":"a group!","metadata":{}}]
+
+POST /vlans/groups
+
+	$ curl -X POST http://localhost:19000/vlans/groups --data-binary '{"description":"another group"}'
+	{"id":"89be5c67-3ddc-4ca3-acbb-f78d96181aa9","description":"another group","metadata":{}}
+
+GET /vlans/groups/{vlanGroupID}
+
+	$ curl http://localhost:19000/vlans/groups/122be0b1-d621-4bf5-8b6b-6d0ce41d7c11
+	{"id":"122be0b1-d621-4bf5-8b6b-6d0ce41d7c11","description":"a group!","metadata":{}}
+
+PATCH /vlans/groups/{vlanGroupID}
+
+	$ curl -X PATCH http://localhost:19000/vlans/groups/89be5c67-3ddc-4ca3-acbb-f78d96181aa9 --data-binary '{"description":"updated description"}'
+	{"id":"89be5c67-3ddc-4ca3-acbb-f78d96181aa9","description":"updated description","metadata":{}}
+
+DELETE /vlans/groups/{vlanGroupID}
+
+	$ curl -X DELETE http://localhost:19000/vlans/groups/89be5c67-3ddc-4ca3-acbb-f78d96181aa9
+	{"id":"89be5c67-3ddc-4ca3-acbb-f78d96181aa9","description":"updated description","metadata":{}}
+
+GET /vlans/tags/{vlanGroupID}/tags
+
+	$ curl -X GET http://localhost:19000/vlans/groups/122be0b1-d621-4bf5-8b6b-6d0ce41d7c11/tags
+	[219]
+
+POST /vlans/tags/{vlanGroupID}/tags
+
+	$ curl -X POST http://localhost:19000/vlans/groups/122be0b1-d621-4bf5-8b6b-6d0ce41d7c11/tags --data-binary '[219]'
+	[219]
+*/
+package main

--- a/cmd/cnetworkd/helpers.go
+++ b/cmd/cnetworkd/helpers.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"code.google.com/p/go-uuid/uuid"
+
+	"github.com/gorilla/mux"
+	"github.com/mistifyio/lochness"
+)
+
+func getVLANHelper(hr HTTPResponse, r *http.Request) (*lochness.VLAN, bool) {
+	ctx := GetContext(r)
+	vars := mux.Vars(r)
+	vt, ok := vars["vlanTag"]
+	if !ok {
+		hr.JSONMsg(http.StatusBadRequest, "missing vlan tag")
+		return nil, false
+	}
+	vlanTag, err := strconv.Atoi(vt)
+	if err != nil {
+		hr.JSONMsg(http.StatusBadRequest, "invalid vlan tag")
+		return nil, false
+	}
+
+	vlan, err := ctx.VLAN(vlanTag)
+	if err != nil {
+		if lochness.IsKeyNotFound(err) {
+			hr.JSONMsg(http.StatusNotFound, "tag not found")
+		} else {
+			hr.JSONError(http.StatusInternalServerError, err)
+		}
+		return nil, false
+	}
+	return vlan, true
+}
+
+func saveVLANHelper(hr HTTPResponse, vlan *lochness.VLAN) bool {
+	if err := vlan.Validate(); err != nil {
+		hr.JSONMsg(http.StatusBadRequest, err.Error())
+		return false
+	}
+
+	if err := vlan.Save(); err != nil {
+		hr.JSONError(http.StatusInternalServerError, err)
+		return false
+	}
+	return true
+}
+
+func decodeVLAN(r *http.Request, vlan *lochness.VLAN) (*lochness.VLAN, error) {
+	if vlan == nil {
+		ctx := GetContext(r)
+		vlan = ctx.NewVLAN()
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(vlan); err != nil {
+		return nil, err
+	}
+	return vlan, nil
+}
+
+func getVLANGroupHelper(hr HTTPResponse, r *http.Request) (*lochness.VLANGroup, bool) {
+	ctx := GetContext(r)
+	vars := mux.Vars(r)
+	groupID, ok := vars["vlanGroupID"]
+	if !ok {
+		hr.JSONMsg(http.StatusBadRequest, "missing group id")
+		return nil, false
+	}
+	if uuid.Parse(groupID) == nil {
+		hr.JSONMsg(http.StatusBadRequest, "invalid group id")
+		return nil, false
+	}
+
+	vlanGroup, err := ctx.VLANGroup(groupID)
+	if err != nil {
+		if lochness.IsKeyNotFound(err) {
+			hr.JSONMsg(http.StatusNotFound, "group not found")
+		} else {
+			hr.JSONError(http.StatusInternalServerError, err)
+		}
+		return nil, false
+	}
+	return vlanGroup, true
+}
+
+func saveVLANGroupHelper(hr HTTPResponse, vlanGroup *lochness.VLANGroup) bool {
+	if err := vlanGroup.Validate(); err != nil {
+		hr.JSONMsg(http.StatusBadRequest, err.Error())
+		return false
+	}
+
+	if err := vlanGroup.Save(); err != nil {
+		hr.JSONError(http.StatusInternalServerError, err)
+		return false
+	}
+	return true
+}
+
+func decodeVLANGroup(r *http.Request, vlanGroup *lochness.VLANGroup) (*lochness.VLANGroup, error) {
+	if vlanGroup == nil {
+		ctx := GetContext(r)
+		vlanGroup = ctx.NewVLANGroup()
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(vlanGroup); err != nil {
+		return nil, err
+	}
+	return vlanGroup, nil
+}

--- a/cmd/cnetworkd/http.go
+++ b/cmd/cnetworkd/http.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+
+	"github.com/bakins/logrus-middleware"
+	"github.com/bakins/net-http-recover"
+	"github.com/gorilla/context"
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
+	"github.com/mistifyio/lochness"
+)
+
+const ctxKey string = "lochnessContext"
+
+type (
+	// HTTPResponse is a wrapper for http.ResponseWriter which provides access
+	// to several convenience methods
+	HTTPResponse struct {
+		http.ResponseWriter
+	}
+
+	// HTTPError contains information for http error responses
+	HTTPError struct {
+		Message string   `json:"message"`
+		Code    int      `json:"code"`
+		Stack   []string `json:"stack"`
+	}
+)
+
+// Run starts the server
+func Run(port uint, ctx *lochness.Context) error {
+	router := mux.NewRouter()
+	router.StrictSlash(true)
+
+	// Common middleware applied to every request
+	logrusMiddleware := logrusmiddleware.Middleware{
+		Name: "cnetworkd",
+	}
+	commonMiddleware := alice.New(
+		func(h http.Handler) http.Handler {
+			return logrusMiddleware.Handler(h, "")
+		},
+		handlers.CompressHandler,
+		func(h http.Handler) http.Handler {
+			return recovery.Handler(os.Stderr, h, true)
+		},
+		func(h http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				context.Set(r, ctxKey, ctx)
+				h.ServeHTTP(w, r)
+			})
+		},
+	)
+
+	// NOTE: Due to weirdness with PrefixPath and StrictSlash, can't just pass
+	// a prefixed subrouter to the register functions and have the base path
+	// work cleanly. The register functions need to add a base path handler to
+	// the main router before setting subhandlers on either main or subrouter
+
+	RegisterVLANRoutes("/vlans/tags", router)
+	RegisterVLANGroupRoutes("/vlans/groups", router)
+
+	server := &http.Server{
+		Addr:           fmt.Sprintf(":%d", port),
+		Handler:        commonMiddleware.Then(router),
+		MaxHeaderBytes: 1 << 20,
+	}
+	return server.ListenAndServe()
+}
+
+// JSON writes appropriate headers and JSON body to the http response
+func (hr *HTTPResponse) JSON(code int, obj interface{}) {
+	hr.Header().Set("Content-Type", "application/json")
+	hr.WriteHeader(code)
+	encoder := json.NewEncoder(hr)
+	if err := encoder.Encode(obj); err != nil {
+		hr.JSONError(http.StatusInternalServerError, err)
+	}
+}
+
+// JSONError prepares an HTTPError with a stack trace and writes it with
+// HTTPResponse.JSON
+func (hr *HTTPResponse) JSONError(code int, err error) {
+	httpError := &HTTPError{
+		Message: err.Error(),
+		Code:    code,
+		Stack:   make([]string, 0, 4),
+	}
+	for i := 1; ; i++ { //
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		// Print this much at least.  If we can't find the source, it won't show.
+		httpError.Stack = append(httpError.Stack, fmt.Sprintf("%s:%d (0x%x)", file, line, pc))
+	}
+	hr.JSON(code, httpError)
+}
+
+// JSONMsg is a convenience method to write a JSON response with just a message
+// string
+func (hr *HTTPResponse) JSONMsg(code int, msg string) {
+	msgObj := map[string]string{
+		"message": msg,
+	}
+	hr.JSON(code, msgObj)
+}
+
+// SetContext sets a lochness.Context value for a request
+func SetContext(r *http.Request, ctx *lochness.Context) {
+	context.Set(r, ctxKey, ctx)
+}
+
+// GetContext retrieves a lochness.Context value for a request
+func GetContext(r *http.Request) *lochness.Context {
+	if value := context.Get(r, ctxKey); value != nil {
+		return value.(*lochness.Context)
+	}
+	return nil
+}

--- a/cmd/cnetworkd/main.go
+++ b/cmd/cnetworkd/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/mistifyio/lochness"
+	logx "github.com/mistifyio/mistify-logrus-ext"
+	flag "github.com/ogier/pflag"
+)
+
+const defaultEtcdAddr = "http://localhost:4001"
+
+func main() {
+	var port uint
+	var etcdAddr, logLevel string
+
+	flag.UintVarP(&port, "port", "p", 19000, "listen port")
+	flag.StringVarP(&etcdAddr, "etcd", "e", defaultEtcdAddr, "address of etcd machine")
+	flag.StringVarP(&logLevel, "log-level", "l", "warn", "log level")
+	flag.Parse()
+
+	if err := logx.DefaultSetup(logLevel); err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"level": logLevel,
+		}).Fatal("failed to set up logging")
+	}
+
+	etcdClient := etcd.NewClient([]string{etcdAddr})
+
+	if !etcdClient.SyncCluster() {
+		log.WithFields(log.Fields{
+			"addr": etcdAddr,
+		}).Fatal("unable to sync etcd cluster")
+	}
+
+	ctx := lochness.NewContext(etcdClient)
+
+	_ = Run(port, ctx)
+}

--- a/cmd/cnetworkd/vlan.go
+++ b/cmd/cnetworkd/vlan.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mistifyio/lochness"
+)
+
+// RegisterVLANRoutes registers the VLAN routes and handlers
+func RegisterVLANRoutes(prefix string, router *mux.Router) {
+	router.HandleFunc(prefix, ListVLANs).Methods("GET")
+	router.HandleFunc(prefix, CreateVLAN).Methods("POST")
+
+	sub := router.PathPrefix(prefix).Subrouter()
+	sub.HandleFunc("/{vlanTag}", GetVLAN).Methods("GET")
+	sub.HandleFunc("/{vlanTag}", UpdateVLAN).Methods("PATCH")
+	sub.HandleFunc("/{vlanTag}", DestroyVLAN).Methods("DELETE")
+	sub.HandleFunc("/{vlanTag}/groups", GetVLANGroupMembership).Methods("GET")
+	sub.HandleFunc("/{vlanTag}/groups", UpdateVLANGroupMembership).Methods("POST")
+}
+
+// ListVLANs gets a list of all VLANs
+func ListVLANs(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	ctx := GetContext(r)
+	vlans := make(lochness.VLANs, 0)
+	err := ctx.ForEachVLAN(func(vlan *lochness.VLAN) error {
+		vlans = append(vlans, vlan)
+		return nil
+	})
+	if err != nil && !lochness.IsKeyNotFound(err) {
+		hr.JSONError(http.StatusInternalServerError, err)
+		return
+	}
+	hr.JSON(http.StatusOK, vlans)
+}
+
+// GetVLAN gets a particular VLAN
+func GetVLAN(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlan, ok := getVLANHelper(hr, r)
+	if !ok {
+		return
+	}
+	hr.JSON(http.StatusOK, vlan)
+}
+
+// CreateVLAN creates a new VLAN
+func CreateVLAN(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlan, err := decodeVLAN(r, nil)
+	if err != nil {
+		hr.JSONMsg(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if !saveVLANHelper(hr, vlan) {
+		return
+	}
+	hr.JSON(http.StatusCreated, vlan)
+}
+
+// UpdateVLAN updates a VLAN
+func UpdateVLAN(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlan, ok := getVLANHelper(hr, r)
+	if !ok {
+		return
+	}
+
+	vlanTag := vlan.Tag
+
+	_, err := decodeVLAN(r, vlan)
+	if err != nil {
+		hr.JSONMsg(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Don't allow tag redefinition
+	vlan.Tag = vlanTag
+
+	if !saveVLANHelper(hr, vlan) {
+		return
+	}
+
+	hr.JSON(http.StatusOK, vlan)
+}
+
+// DestroyVLAN destroys a VLAN
+func DestroyVLAN(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlan, ok := getVLANHelper(hr, r)
+	if !ok {
+		return
+	}
+
+	if err := vlan.Destroy(); err != nil {
+		hr.JSONError(http.StatusInternalServerError, err)
+	}
+
+	hr.JSON(http.StatusOK, vlan)
+}
+
+// GetVLANGroupMembership gets a VLAN's group membership
+func GetVLANGroupMembership(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlan, ok := getVLANHelper(hr, r)
+	if !ok {
+		return
+	}
+	hr.JSON(http.StatusOK, vlan.VLANGroups())
+}
+
+// UpdateVLANGroupMembership updates a VLAN's group membership
+func UpdateVLANGroupMembership(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlan, ok := getVLANHelper(hr, r)
+	if !ok {
+		return
+	}
+	var newGroups []string
+	if err := json.NewDecoder(r.Body).Decode(&newGroups); err != nil {
+		hr.JSONMsg(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Determine group modifications necessary
+	// -1 : Removed
+	//  0 : No change
+	//  1 : Added
+	ctx := GetContext(r)
+	groupModifications := make(map[string]int)
+	for _, oldGroup := range vlan.VLANGroups() {
+		groupModifications[oldGroup] = -1
+	}
+	for _, newGroup := range newGroups {
+		groupModifications[newGroup]++
+	}
+	// Make group modifications
+	for groupID, action := range groupModifications {
+		vlanGroup, err := ctx.VLANGroup(groupID)
+		if err != nil {
+			if lochness.IsKeyNotFound(err) {
+				hr.JSONMsg(http.StatusBadRequest, "group not found")
+			} else {
+				hr.JSONMsg(http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		switch action {
+		case -1:
+			if err := vlanGroup.RemoveVLAN(vlan); err != nil {
+				hr.JSONError(http.StatusInternalServerError, err)
+				return
+			}
+		case 0:
+			break
+		case 1:
+			if err := vlanGroup.AddVLAN(vlan); err != nil {
+				hr.JSONError(http.StatusInternalServerError, err)
+				return
+			}
+		}
+	}
+
+	hr.JSON(http.StatusOK, vlan.VLANGroups())
+}

--- a/cmd/cnetworkd/vlangroup.go
+++ b/cmd/cnetworkd/vlangroup.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mistifyio/lochness"
+)
+
+// RegisterVLANGroupRoutes registers the VLAN routes and handlers
+func RegisterVLANGroupRoutes(prefix string, router *mux.Router) {
+	router.HandleFunc(prefix, ListVLANGroups).Methods("GET")
+	router.HandleFunc(prefix, CreateVLANGroup).Methods("POST")
+
+	sub := router.PathPrefix(prefix).Subrouter()
+	sub.HandleFunc("/{vlanGroupID}", GetVLANGroup).Methods("GET")
+	sub.HandleFunc("/{vlanGroupID}", UpdateVLANGroup).Methods("PATCH")
+	sub.HandleFunc("/{vlanGroupID}", DestroyVLANGroup).Methods("DELETE")
+	sub.HandleFunc("/{vlanGroupID}/tags", GetVLANGroupVLANs).Methods("GET")
+	sub.HandleFunc("/{vlanGroupID}/tags", UpdateVLANGroupVLANs).Methods("POST")
+}
+
+// ListVLANGroups gets a list of all VLANGroups
+func ListVLANGroups(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	ctx := GetContext(r)
+	vlanGroups := make(lochness.VLANGroups, 0)
+	err := ctx.ForEachVLANGroup(func(vlanGroup *lochness.VLANGroup) error {
+		vlanGroups = append(vlanGroups, vlanGroup)
+		return nil
+	})
+	if err != nil && !lochness.IsKeyNotFound(err) {
+		hr.JSONError(http.StatusInternalServerError, err)
+		return
+	}
+	hr.JSON(http.StatusOK, vlanGroups)
+}
+
+// GetVLANGroup gets a particular VLAN
+func GetVLANGroup(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlanGroup, ok := getVLANGroupHelper(hr, r)
+	if !ok {
+		return
+	}
+	hr.JSON(http.StatusOK, vlanGroup)
+}
+
+// CreateVLANGroup creates a new VLAN
+func CreateVLANGroup(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlanGroup, err := decodeVLANGroup(r, nil)
+	if err != nil {
+		hr.JSONMsg(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if !saveVLANGroupHelper(hr, vlanGroup) {
+		return
+	}
+	hr.JSON(http.StatusCreated, vlanGroup)
+}
+
+// UpdateVLANGroup updates a VLANGroup
+func UpdateVLANGroup(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlanGroup, ok := getVLANGroupHelper(hr, r)
+	if !ok {
+		return
+	}
+
+	groupID := vlanGroup.ID
+
+	_, err := decodeVLANGroup(r, vlanGroup)
+	if err != nil {
+		hr.JSONMsg(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Don't allow ID redefinition
+	vlanGroup.ID = groupID
+
+	if !saveVLANGroupHelper(hr, vlanGroup) {
+		return
+	}
+
+	hr.JSON(http.StatusOK, vlanGroup)
+}
+
+// DestroyVLANGroup destroys a VLANGroup
+func DestroyVLANGroup(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlanGroup, ok := getVLANGroupHelper(hr, r)
+	if !ok {
+		return
+	}
+
+	if err := vlanGroup.Destroy(); err != nil {
+		hr.JSONError(http.StatusInternalServerError, err)
+	}
+
+	hr.JSON(http.StatusOK, vlanGroup)
+}
+
+// GetVLANGroupVLANs gets a VLANGroup's VLANs
+func GetVLANGroupVLANs(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlanGroup, ok := getVLANGroupHelper(hr, r)
+	if !ok {
+		return
+	}
+	hr.JSON(http.StatusOK, vlanGroup.VLANs())
+}
+
+// UpdateVLANGroupVLANs updates a VLANGroups's VLANs
+func UpdateVLANGroupVLANs(w http.ResponseWriter, r *http.Request) {
+	hr := HTTPResponse{w}
+	vlanGroup, ok := getVLANGroupHelper(hr, r)
+	if !ok {
+		return
+	}
+	var newTags []int
+	if err := json.NewDecoder(r.Body).Decode(&newTags); err != nil {
+		hr.JSONMsg(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Determine group modifications necessary
+	// -1 : Removed
+	//  0 : No change
+	//  1 : Added
+	ctx := GetContext(r)
+	groupModifications := make(map[int]int)
+	for _, oldTag := range vlanGroup.VLANs() {
+		groupModifications[oldTag] = -1
+	}
+	for _, newTag := range newTags {
+		groupModifications[newTag]++
+	}
+
+	// Make group modifications
+	for tag, action := range groupModifications {
+		vlan, err := ctx.VLAN(tag)
+		if err != nil {
+			if lochness.IsKeyNotFound(err) {
+				hr.JSONMsg(http.StatusBadRequest, "vlan not found")
+			} else {
+				hr.JSONMsg(http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		switch action {
+		case -1:
+			if err := vlanGroup.RemoveVLAN(vlan); err != nil {
+				hr.JSONError(http.StatusInternalServerError, err)
+				return
+			}
+		case 0:
+			break
+		case 1:
+			if err := vlanGroup.AddVLAN(vlan); err != nil {
+				hr.JSONError(http.StatusInternalServerError, err)
+				return
+			}
+		}
+	}
+
+	hr.JSON(http.StatusOK, vlanGroup.VLANs())
+}

--- a/guest.go
+++ b/guest.go
@@ -32,6 +32,7 @@ type (
 		NetworkID     string            `json:"network"`
 		SubnetID      string            `json:"subnet"`
 		FWGroupID     string            `json:"fwgroup"`
+		VLANGroupID   string            `json:"vlangroup"`
 		MAC           net.HardwareAddr  `json:"mac"`
 		IP            net.IP            `json:"ip"`
 		Bridge        string            `json:"bridge"`
@@ -50,6 +51,7 @@ type (
 		NetworkID    string            `json:"network"`
 		SubnetID     string            `json:"subnet"`
 		FWGroupID    string            `json:"fwgroup"`
+		VLANGroupID  string            `json:"vlangroup"`
 		MAC          string            `json:"mac"`
 		IP           net.IP            `json:"ip"`
 		Bridge       string            `json:"bridge"`
@@ -69,6 +71,7 @@ func (g *Guest) MarshalJSON() ([]byte, error) {
 		NetworkID:    g.NetworkID,
 		SubnetID:     g.SubnetID,
 		FWGroupID:    g.FWGroupID,
+		VLANGroupID:  g.VLANGroupID,
 		HypervisorID: g.HypervisorID,
 		IP:           g.IP,
 		MAC:          g.MAC.String(),
@@ -106,6 +109,9 @@ func (g *Guest) UnmarshalJSON(input []byte) error {
 	}
 	if data.FWGroupID != "" {
 		g.FWGroupID = data.FWGroupID
+	}
+	if data.VLANGroupID != "" {
+		g.VLANGroupID = data.VLANGroupID
 	}
 	if data.HypervisorID != "" {
 		g.HypervisorID = data.HypervisorID

--- a/mistifyagent.go
+++ b/mistifyagent.go
@@ -59,6 +59,15 @@ func (agent *MistifyAgent) generateClientGuest(g *Guest) (*client.Guest, error) 
 		return nil, err
 	}
 
+	var vlans []int
+	if g.VLANGroupID != "" {
+		vlanGroup, err := agent.context.VLANGroup(g.VLANGroupID)
+		if err != nil {
+			return nil, err
+		}
+		vlans = vlanGroup.VLANs()
+	}
+
 	nic := client.Nic{
 		Name:    "eth0",
 		Network: g.Bridge,
@@ -67,6 +76,7 @@ func (agent *MistifyAgent) generateClientGuest(g *Guest) (*client.Guest, error) 
 		Address: g.IP.String(),
 		Netmask: subnet.CIDR.Mask.String(),
 		Gateway: subnet.Gateway.String(),
+		VLANs:   vlans,
 	}
 
 	disk := client.Disk{

--- a/mistifyagent.go
+++ b/mistifyagent.go
@@ -68,6 +68,11 @@ func (agent *MistifyAgent) generateClientGuest(g *Guest) (*client.Guest, error) 
 		vlans = vlanGroup.VLANs()
 	}
 
+	// Default to vlan tag 1
+	if len(vlans) == 0 {
+		vlans = []int{1}
+	}
+
 	nic := client.Nic{
 		Name:    "eth0",
 		Network: g.Bridge,

--- a/vlan.go
+++ b/vlan.go
@@ -1,0 +1,154 @@
+package lochness
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+var (
+	// VLANPath is the path in the config store for VLANs
+	VLANPath = "/lochness/vlans/"
+)
+
+type (
+	// VLAN devines the virtual lan for a guest interface
+	VLAN struct {
+		context       *Context
+		modifiedIndex uint64
+		Tag           int    `json:"tag"`
+		Description   string `json:"description"`
+		vlanGroups    []string
+	}
+
+	// VLANs is an alias to a slice of *VLAN
+	VLANs []*VLAN
+)
+
+func (c *Context) blankVLAN(tag int) *VLAN {
+	if tag == 0 {
+		tag = 1
+	}
+
+	v := &VLAN{
+		context:    c,
+		Tag:        tag,
+		vlanGroups: make([]string, 0, 0),
+	}
+
+	return v
+}
+
+// NewVLAN creates a new blank VLAN.
+func (c *Context) NewVLAN() *VLAN {
+	return c.blankVLAN(0)
+}
+
+// key is a helper to generate the config store key.
+func (v *VLAN) key() string {
+	return filepath.Join(VLANPath, string(v.Tag), "metadata")
+}
+
+func (v *VLAN) vlanGroupKey(vlanGroup *VLANGroup) string {
+	var key string
+	if vlanGroup != nil {
+		key = vlanGroup.ID
+	}
+	return filepath.Join(VLANPath, string(v.Tag), "vlangroups", key)
+}
+
+// VLAN fetches a VLAN from the data store.
+func (c *Context) VLAN(tag int) (*VLAN, error) {
+	v := c.blankVLAN(tag)
+	if err := v.Refresh(); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// Refresh reloads the VLAN from the data store.
+func (v *VLAN) Refresh() error {
+	resp, err := v.context.etcd.Get(filepath.Dir(v.key()), false, false)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range resp.Node.Nodes {
+		key := filepath.Base(node.Key)
+		switch key {
+		case "metadata":
+			if err := json.Unmarshal([]byte(node.Value), &v); err != nil {
+				return err
+			}
+			v.modifiedIndex = node.ModifiedIndex
+		case "vlangroups":
+			for _, x := range node.Nodes {
+				v.vlanGroups = append(v.vlanGroups, x.Key)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Validate ensures a VLAN has resonable data.
+func (v *VLAN) Validate() error {
+	if v.Tag <= 0 {
+		return errors.New("invalid tag")
+	}
+	return nil
+}
+
+// Save persists a VLAN. It will call Validate.
+func (v *VLAN) Save() error {
+	if err := v.Validate(); err != nil {
+		return err
+	}
+
+	value, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	// if something changed, don't clobber
+	var resp *etcd.Response
+	if v.modifiedIndex != 0 {
+		resp, err = v.context.etcd.CompareAndSwap(v.key(), string(value), 0, "", v.modifiedIndex)
+	} else {
+		resp, err = v.context.etcd.Create(v.key(), string(value), 0)
+	}
+	if err != nil {
+		return err
+	}
+
+	v.modifiedIndex = resp.EtcdIndex
+
+	return nil
+}
+
+// Destroy removes the VLAN
+func (v *VLAN) Destroy() error {
+	// Unlink VLANGroups
+	for _, vlanGroupID := range v.vlanGroups {
+		vlanGroup, err := v.context.VLANGroup(vlanGroupID)
+		if err != nil {
+			return err
+		}
+		if err := vlanGroup.RemoveVLAN(v); err != nil {
+			return err
+		}
+	}
+
+	// Delete the VLAN
+	if _, err := v.context.etcd.Delete(filepath.Dir(v.key()), true); err != nil {
+		return err
+	}
+	return nil
+}
+
+// VLANGroups returns the IDs of the VLANGroups associated with the VLAN
+func (v *VLAN) VLANGroups() []string {
+	return v.vlanGroups
+}

--- a/vlan.go
+++ b/vlan.go
@@ -96,7 +96,8 @@ func (v *VLAN) Refresh() error {
 
 // Validate ensures a VLAN has resonable data.
 func (v *VLAN) Validate() error {
-	if v.Tag <= 0 {
+	// Tag must be positive and fit in 12bit
+	if v.Tag <= 0 || v.Tag > 4095 {
 		return errors.New("invalid tag")
 	}
 	return nil

--- a/vlangroup.go
+++ b/vlangroup.go
@@ -1,0 +1,212 @@
+package lochness
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strconv"
+
+	"code.google.com/p/go-uuid/uuid"
+
+	"github.com/coreos/go-etcd/etcd"
+)
+
+var (
+	// VLANGroupPath is the path in the config store for VLAN groups
+	VLANGroupPath = "/lochness/vlangroups/"
+)
+
+type (
+	// VLANGroup defines a set of VLANs for a guest interface
+	VLANGroup struct {
+		context       *Context
+		modifiedIndex uint64
+		ID            string            `json:"id"`
+		Description   string            `json:"description"`
+		Metadata      map[string]string `json:"metadata"`
+		vlans         []int
+	}
+
+	// VLANGroups is an alias to a slice of *VLANGroup
+	VLANGroups []*VLANGroup
+)
+
+func (c *Context) blankVLANGroup(id string) *VLANGroup {
+	vg := &VLANGroup{
+		context:  c,
+		ID:       id,
+		Metadata: make(map[string]string),
+		vlans:    make([]int, 0, 0),
+	}
+
+	if id == "" {
+		vg.ID = uuid.New()
+	}
+
+	return vg
+}
+
+// key is a helper to generate the config store key.
+func (vg *VLANGroup) key() string {
+	return filepath.Join(VLANGroupPath, vg.ID, "metadata")
+}
+
+func (vg *VLANGroup) vlanKey(vlan *VLAN) string {
+	var key int
+	if vlan != nil {
+		key = vlan.Tag
+	}
+	return filepath.Join(VLANGroupPath, vg.ID, "vlans", string(key))
+}
+
+// NewVLANGroup creates a new blank VLANGroup.
+func (c *Context) NewVLANGroup() *VLANGroup {
+	return c.blankVLANGroup("")
+}
+
+// VLANGroup fetches a VLAN from the data store.
+func (c *Context) VLANGroup(id string) (*VLANGroup, error) {
+	var err error
+	id, err = canonicalizeUUID(id)
+	if err != nil {
+		return nil, err
+	}
+	vg := c.blankVLANGroup(id)
+	if err = vg.Refresh(); err != nil {
+		return nil, err
+	}
+	return vg, nil
+}
+
+// Refresh reloads the VLAN from the data store.
+func (vg *VLANGroup) Refresh() error {
+	resp, err := vg.context.etcd.Get(filepath.Dir(vg.key()), false, false)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range resp.Node.Nodes {
+		key := filepath.Base(node.Key)
+		switch key {
+		case "metadata":
+			if err := json.Unmarshal([]byte(node.Value), &vg); err != nil {
+				return err
+			}
+			vg.modifiedIndex = node.ModifiedIndex
+		case "vlans":
+			for _, x := range node.Nodes {
+				vlanTag, _ := strconv.Atoi(filepath.Base(x.Key))
+				vg.vlans = append(vg.vlans, vlanTag)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Validate ensures a VLANGroup has resonable data.
+func (vg *VLANGroup) Validate() error {
+	if _, err := canonicalizeUUID(vg.ID); err != nil {
+		return errors.New("invalid ID")
+	}
+	return nil
+}
+
+// Save persists a VLANgroup. It will call Validate.
+func (vg *VLANGroup) Save() error {
+	if err := vg.Validate(); err != nil {
+		return err
+	}
+
+	value, err := json.Marshal(vg)
+	if err != nil {
+		return err
+	}
+
+	// if something changed, don't clobber
+	var resp *etcd.Response
+	if vg.modifiedIndex != 0 {
+		resp, err = vg.context.etcd.CompareAndSwap(vg.key(), string(value), 0, "", vg.modifiedIndex)
+	} else {
+		resp, err = vg.context.etcd.Create(vg.key(), string(value), 0)
+	}
+	if err != nil {
+		return err
+	}
+
+	vg.modifiedIndex = resp.EtcdIndex
+	return nil
+}
+
+// Destroy removes a VLANGroup
+func (vg *VLANGroup) Destroy() error {
+	// Unlink VLANs
+	for _, vlanTag := range vg.vlans {
+		vlan, err := vg.context.VLAN(vlanTag)
+		if err != nil {
+			return err
+		}
+		if err := vg.RemoveVLAN(vlan); err != nil {
+			return err
+		}
+	}
+
+	// Delete the VLANGroup
+	if _, err := vg.context.etcd.Delete(filepath.Dir(vg.key()), true); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AddVLAN adds a VLAN to the VLANGroup
+func (vg *VLANGroup) AddVLAN(vlan *VLAN) error {
+	// VLANGroup side
+	if _, err := vg.context.etcd.Set(vg.vlanKey(vlan), "", 0); err != nil {
+		return err
+	}
+	vg.vlans = append(vg.vlans, vlan.Tag)
+
+	// VLAN side
+	if _, err := vlan.context.etcd.Set(vlan.vlanGroupKey(vg), "", 0); err != nil {
+		return err
+	}
+	vlan.vlanGroups = append(vlan.vlanGroups, vg.ID)
+
+	return nil
+}
+
+// RemoveVLAN removes a VLAN from the VLANGroup
+func (vg *VLANGroup) RemoveVLAN(vlan *VLAN) error {
+	// VLANGroup side
+	if _, err := vg.context.etcd.Delete(vg.vlanKey(vlan), false); err != nil {
+		return err
+	}
+
+	newVLANs := make([]int, 0, len(vg.vlans)-1)
+	for _, vlanTag := range vg.vlans {
+		if vlanTag != vlan.Tag {
+			newVLANs = append(newVLANs, vlanTag)
+		}
+	}
+	vg.vlans = newVLANs
+
+	// VLAN side
+	if _, err := vlan.context.etcd.Delete(vlan.vlanGroupKey(vg), false); err != nil {
+		return err
+	}
+
+	newVLANGroups := make([]string, 0, len(vlan.vlanGroups)-1)
+	for _, vlanGroup := range vlan.vlanGroups {
+		if vlanGroup != vg.ID {
+			newVLANGroups = append(newVLANGroups, vlanGroup)
+		}
+	}
+	vlan.vlanGroups = newVLANGroups
+
+	return nil
+}
+
+// VLANs returns the Tags of the VLANs associated with the VLANGroup
+func (vg *VLANGroup) VLANs() []int {
+	return vg.vlans
+}


### PR DESCRIPTION
cnetworkd is the management API for VLAN tags and VLAN Groups. Guests can be given a VLAN Group ID and the associated tags will be applied to the nics (When we build better support for multiple nics, the vlan group id can be moved to the nic level)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/lochness/116)
<!-- Reviewable:end -->
